### PR TITLE
🐛 Deep copy field default attributes on object instantiation

### DIFF
--- a/pykorm/meta.py
+++ b/pykorm/meta.py
@@ -1,3 +1,4 @@
+import copy
 import inspect
 from typing import Dict
 
@@ -79,7 +80,7 @@ class ModelMixin(metaclass=ModelMeta):
         attr = object.__getattribute__(self, item)
 
         if isinstance(attr, fields.DataField):
-            return attr.default
+            return copy.deepcopy(attr.default)
         else:
             return attr
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ class Apple(ScoreMixin, pykorm.ClusterModel):
 class Peach(ScoreMixin, pykorm.NamespacedModel):
     variety: str = pykorm.fields.Spec('variety', 'default-variety')
     price: str = pykorm.fields.Spec('price', 1)
+    colours: list = pykorm.fields.Spec('colours', [])
 
 
 @pytest.fixture

--- a/tests/crds/pykorm_crd_peach.yaml
+++ b/tests/crds/pykorm_crd_peach.yaml
@@ -25,6 +25,10 @@ spec:
                   type: string
                 price:
                   type: integer
+                colours:
+                  type: array
+                  items:
+                    type: string
                 score:
                   type: object
                   properties:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,3 +1,4 @@
+from tests.conftest import Peach
 from pykorm import fields
 from pykorm.models import Nested
 
@@ -164,3 +165,11 @@ def test_metadata_annotations_field():
 def test_metadata_annotations_field_default():
     md = fields.MetadataAnnotation('ch.infomaniak.pykorm/foo.bar', 'default')
     assert md.get_data({}) == 'default'
+
+
+def test_field_copy_default():
+    p1 = Peach(namespace='default', name='blue-peach')
+    p1.colours.append('blue')
+
+    p2 = Peach(namespace='default', name='colourless-peach')
+    assert p2.colours == []  # `colours` field default attribute is []


### PR DESCRIPTION
Default attributes were not copied by default, which resulted in the
reuse of objects. This fixes #27