### PR TITLE
WIP: Cls: allow not having a valid kubeconfig at runtime

### DIFF
--- a/pykorm/pykorm.py
+++ b/pykorm/pykorm.py
@@ -66,7 +66,12 @@ class Pykorm:
             # To be changed once https://github.com/kubernetes-client/python/issues/1005 is fixed
             kubernetes.config.load_kube_config()
         except kubernetes.config.config_exception.ConfigException:
-            kubernetes.config.load_incluster_config()
+            try:
+                kubernetes.config.load_incluster_config()
+            except:
+                # Not a problem for now a users can later specify a custom kubeconfig
+                # with pykorm.Pykorm.clusters_config = dict[cluster_name, kubeconfig]
+                pass
 
         api_client = kubernetes.client.ApiClient()
         api_client_mapping['default'] = api_client


### PR DESCRIPTION
It should be possible to import objects before having a valid
kubeconfig as it can be provided later.

Signed-off-by: Frank Villaro-Dixon <frank.villaro@infomaniak.com>