### PR TITLE
ListField : allow undefined value if not required

### DIFF
--- a/pykorm/fields.py
+++ b/pykorm/fields.py
@@ -92,9 +92,13 @@ class ListField(DataField):
 
     def get_data(self, k8s_dict: Dict):
         ret = []
-        full_items = dpath.util.get(k8s_dict, self.fullpath) or []
-        for sub_dict in full_items:
-            ret.append(self.dict_nested_field.get_data(sub_dict))
+        try:
+            full_items = dpath.util.get(k8s_dict, self.fullpath) or []
+            for sub_dict in full_items:
+                ret.append(self.dict_nested_field.get_data(sub_dict))
+        except KeyError:
+            if self.required:
+                raise Exception(f'ListField {self.path} is required.')
         return ret
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ class Peach(ScoreMixin, pykorm.NamespacedModel):
     variety: str = pykorm.fields.Spec('variety', 'default-variety')
     price: str = pykorm.fields.Spec('price', 1)
     colours: list = pykorm.fields.Spec('colours', [])
+    scores: [Score] = pykorm.fields.ListField(Score, path=['scores'])
 
 
 @pykorm.pykorm.k8s_core(kind='Namespace')

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -23,6 +23,16 @@ def test_filter_attr(pk):
     assert(b_peaches == all_peaches['b'])
 
 
+def test_filter_undefined_listfield(pk):
+    peach = Peach(namespace='default', name='delicious', variety='a')
+    pk.apply(peach)
+
+    a_peach = Peach.query.filter_by(namespace='default', name='delicious').all()
+    assert a_peach is not None
+    assert len(a_peach) > 0
+    assert len(a_peach) == 1
+
+
 def test_filter_chain(pk):
     all_peaches = {}
     for variety in ['a', 'b', 'c']:


### PR DESCRIPTION
If a ListField attribute is not defined while making a query, you'll get a KeyError exception. As an attribute can be not required, this shouldn't happen.

For example:
```python
class Subject(pykorm.models.Nested):
    kind: str = pykorm.fields.DataField('kind')
    name: str = pykorm.fields.DataField('name')
    namespace: str = pykorm.fields.DataField('namespace')
    apiGroup: str = pykorm.fields.DataField('apiGroup')


class RoleRef(pykorm.models.Nested):
    kind: str = pykorm.fields.DataField('kind')
    name: str = pykorm.fields.DataField('name')
    apiGroup: str = pykorm.fields.DataField('apiGroup')


@pykorm.pykorm.k8s_custom_object('rbac.authorization.k8s.io', 'v1', 'clusterrolebindings')
class ClusterRoleBinding(pykorm.models.ClusterModel):
    roleRef: RoleRef = pykorm.fields.DictNestedField(RoleRef, path=['roleRef'])
    subjects: List[Subject] = pykorm.fields.ListField(Subject, path=['subjects'])
```

Let's say that in your cluster there is the following `ClusterRoleBinding`:

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  labels:
    kubernetes.io/bootstrapping: rbac-defaults
  name: system:node
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: system:node
```

Then when you'll make the following query:

```python
>>> ClusterRoleBinding.query.filter_by(name="system:node").all()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/hedinasr/src/operator-project/.direnv/python-3.10.9/lib/python3.10/site-packages/pykorm/query.py", line 153, in all
    last_ret = self._query(data=last_ret, **_filter.kwargs)
  File "/Users/hedinasr/src/operator-project/.direnv/python-3.10.9/lib/python3.10/site-packages/pykorm/query.py", line 143, in _query
    for el in data:
  File "/Users/hedinasr/src/operator-project/.direnv/python-3.10.9/lib/python3.10/site-packages/pykorm/query.py", line 296, in _iter
    yield self.baseobject._instantiate_with_dict(obj, queryset=self)
  File "/Users/hedinasr/src/operator-project/.direnv/python-3.10.9/lib/python3.10/site-packages/pykorm/models.py", line 46, in _instantiate_with_dict
    obj._set_attributes_with_dict(k8s_dict)
  File "/Users/hedinasr/src/operator-project/.direnv/python-3.10.9/lib/python3.10/site-packages/pykorm/models.py", line 55, in _set_attributes_with_dict
    value = attr.get_data(k8s_dict)
  File "/Users/hedinasr/src/operator-project/.direnv/python-3.10.9/lib/python3.10/site-packages/pykorm/fields.py", line 97, in get_data
    full_items = dpath.util.get(k8s_dict, self.fullpath) or []
  File "/Users/hedinasr/src/operator-project/.direnv/python-3.10.9/lib/python3.10/site-packages/dpath/util.py", line 177, in get
    raise KeyError(glob)
KeyError: ['subjects']
```

I added a test case that should fail with the exact same error without the patch in the `ListField.get_data` function.